### PR TITLE
Dockerize the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /db
 /deps
 /*.ez
+/.vscode
 
 # Generate on crash by the VM
 erl_crash.dump
@@ -25,3 +26,4 @@ erl_crash.dump
 /priv/static/
 
 /tmp
+/yarn.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM edib/elixir-phoenix-dev:1.4
+MAINTAINER John Dave Decano <johndavedecano@gmail.com>
+
+RUN npm install -g --silent brunch
+
+WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ You need to setup a postgresql DB version 9.5
 4. add others parameters from dev.secret into Heroku config:set
 5. You're good to go!
 
+## Using Docker For Development
+1. Give you already have docker and docker-compose installed on your machine, Simply run these following commands:
+```
+# Build all and pull images and containers
+docker-compose build
+# Build application dependencies.
+chmod +x build # This will set permission to allow our build script to run.
+./build
+# Build the Docker image and start the `web` container, daemonized
+docker-compose up -d web
+```
+
 ## Contribution
 Feel free to send your PR with proposals, improvements or corrections!
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You need to setup a postgresql DB version 9.5
 5. You're good to go!
 
 ## Using Docker For Development
-1. Give you already have docker and docker-compose installed on your machine, Simply run these following commands:
+1. Given you already have docker and docker-compose installed on your machine, Simply run these following commands:
 ```
 # Build all and pull images and containers
 docker-compose build

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ You need to setup a postgresql DB version 9.5
 # Build all and pull images and containers
 docker-compose build
 # Build application dependencies.
-chmod +x build # This will set permission to allow our build script to run.
+# This will set permission to allow our build script to run.
+chmod +x build
 ./build
 # Build the Docker image and start the `web` container, daemonized
 docker-compose up -d web

--- a/build
+++ b/build
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+docker-compose run web mix deps.get
+docker-compose run web mix compile
+docker-compose run web mix ecto.create
+docker-compose run web mix ecto.migrate
+docker-compose run web yarn
+docker-compose run web node node_modules/brunch/bin/brunch build

--- a/config/dev.secret.docker_example.exs
+++ b/config/dev.secret.docker_example.exs
@@ -1,0 +1,35 @@
+use Mix.Config
+
+# In this file, we keep production configuration that
+# you likely want to automate and keep it away from
+# your version control system.
+# Configure your database
+config :cercleApi, CercleApi.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  username: System.get_env("DB_USER"),
+  password: System.get_env("DB_PASS"),
+  database: System.get_env("DB_NAME"),
+  hostname: System.get_env("DB_HOST"),
+  pool_size: 10
+
+config :arc,
+  bucket: System.get_env("AWS_BUCKET"),
+  virtual_host: true
+
+config :ex_aws,
+  access_key_id: System.get_env("AWS_KEY"),
+  secret_access_key: System.get_env("AWS_SECRET"),
+  region: System.get_env("AWS_REGION")
+
+config :cercleApi, basic_auth: [
+    username: "admin",
+    password: "admin",
+    realm: "Admin Area"
+  ]
+
+config :mailman,
+  relay: System.get_env("SMTP_HOST"),            
+  port: System.get_env("SMTP_PORT"),
+  username: System.get_env("SMTP_USER"),
+  password: System.get_env("SMTP_PASS"),
+  tls: :always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+web:
+  build: .
+  dockerfile: Dockerfile
+  command: mix phoenix.server
+  environment:
+    - MIX_ENV=dev
+    - PORT=4000
+    - AWS_BUCKET=
+    - AWS_KEY=
+    - AWS_SECRET=
+    - AWS_REGION=
+    - SMTP_HOST=smtp.postmarkapp.com
+    - SMTP_PORT=587
+    - SMTP_USER=user
+    - SMTP_PASS=pass
+    - DB_USER=postgres
+    - DB_PASS=postgres
+    - DB_NAME=cercle_dev
+    - DB_HOST=postgres
+  volumes:
+    - .:/app
+  ports:
+    - "4000:4000"
+  links:
+    - postgres
+postgres:
+  image: postgres:9.6.1
+  ports:
+    - "5432"

--- a/mix.exs
+++ b/mix.exs
@@ -59,7 +59,7 @@ defmodule CercleApi.Mixfile do
   #
   # See the documentation for `Mix` for more info on aliases.
   defp aliases do
-    ["ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
+    ["ecto.setup": ["ecto.create", "ecto.migrate"],
      "ecto.reset": ["ecto.drop", "ecto.setup"],
      "test": ["ecto.create --quiet", "ecto.migrate", "test"]]
   end


### PR DESCRIPTION
Use docker and docker-compose in order to easily onboard other developers. Docker will allow each developer to have same development environment to avoid dependency inconsistencies.